### PR TITLE
docker: store CANopenEditor binaries

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,6 +12,13 @@ RUN apt-get -y update && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
+COPY ../CANopenEditor-v4 /opt/CANopenEditor-v4/
+COPY ../scripts /opt/CANopenEditor-v4/scripts/
+
+RUN chmod -R +x /opt/CANopenEditor-v4/scripts/
+
+ENV PATH="/opt/CANopenEditor-v4/scripts:$PATH"
+
 # Create workdir folder and set as default
 RUN mkdir /workdir
 WORKDIR /workdir

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,14 +4,13 @@
     {
       "label": "Open CANopenEditor",
       "type": "shell",
-      "command": "mono ./CANopenEditor-v4/net481/EDSEditor.exe"
+      "command": "EDSEditor"
     },
     {
       "label": "Convert EDS",
       "type": "shell",
-      "command": "mono",
+      "command": "EDSSharp",
       "args": [
-        "./CANopenEditor-v4/net481/EDSSharp.exe",
         "--infile", "${input:edsFile}",
         "--outfile", "${input:outFile}",
         "--type", "${input:type}"

--- a/scripts/EDSEditor
+++ b/scripts/EDSEditor
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec mono "/opt/CANopenEditor-v4/net481/EDSEditor.exe" "$@"

--- a/scripts/EDSSharp
+++ b/scripts/EDSSharp
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec mono "/opt/CANopenEditor-v4/net481/EDSSharp.exe" "$@"

--- a/test/test_OD_output.sh
+++ b/test/test_OD_output.sh
@@ -10,7 +10,7 @@ rm -f test/OD.*
 docker run --rm \
   -v "$PWD:/workdir" \
   canopeneditor \
-  mono ./CANopenEditor-v4/net481/EDSSharp.exe \
+  EDSSharp \
     --infile ./demoDevice.xdd \
     --outfile ./test/OD \
     --type CanOpenNodeV4


### PR DESCRIPTION
- Store CANopenEditor binaries inside the docker image
- Add launcher files to encapsulate mono commands
- Add launcher files to PATH
- Update tasks.json
- Update test scripts with launcher commands