### PR TITLE
ci: split ci into several jobs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get -y update && \
 	apt-get clean && \
 	rm -rf /var/lib/apt/lists/*
 
-COPY ../CANopenEditor-v4 /opt/CANopenEditor-v4/
+COPY ../CANopenEditor-v4/ /opt/CANopenEditor-v4/
 COPY ../scripts /opt/CANopenEditor-v4/scripts/
 
 RUN chmod -R +x /opt/CANopenEditor-v4/scripts/

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -7,9 +7,8 @@ name: Docker
 
 on:
   push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -65,6 +64,15 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          tags: ${{ env.TEST_TAG }}
+
+      - name: Test CANopenEditor OD conversion inside docker
+        run: bash test/test_OD_output.sh
+
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
@@ -74,7 +82,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           file: .devcontainer/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -94,3 +102,23 @@ jobs:
         # This step uses the identity token to provision an ephemeral certificate
         # against the sigstore community Fulcio instance.
         run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+
+      - name: Append Docker image tags to CHANGELOG.md
+        run: |
+          echo "" >> CHANGELOG.md
+          echo "## Docker Images" >> CHANGELOG.md
+          for tag in ${{ steps.meta.outputs.tags }}; do
+            echo "- \`docker pull $tag\`" >> CHANGELOG.md
+          done
+
+      - name: Create release
+        uses: actions/create-release@v1
+        id: create_release
+        with:
+          draft: false
+          prerelease: false
+          release_name: release_${{ github.ref }}
+          tag_name: ${{ github.ref }}
+          body_path: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Dockerfile linter
+
+on: [ push ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+      
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: .devcontainer/Dockerfile

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,26 @@
+name: Unit test
+
+on:
+  push:
+    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+      
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Test CANopenEditor OD conversion inside docker
+        run: bash test/test_OD_output.sh

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 This repository provides a Docker image bundling [CANopenEditor](https://github.com/CANopenNode/CANopenEditor), a GUI tool for editing CANopen EDS and DCF files.
 Integration in VSCode is provided inside DevContainer if you are not confident with docker commands.
 
+- Supported architectures:
+linux/amd64, linux/arm64
+
 ## Requirements
 
 - Docker (or similar)
@@ -35,19 +38,19 @@ Or manually:
 
 ```shell
 # Inside the container
-mono ./CANopenEditor-v4/net481/EDSEditor.exe
+EDSEditor
 ```
 
 ### How to use (CLI)
 
 ```shell
 # Inside the container
-mono ./CANopenEditor-v4/net481/EDSSharp.exe --infile <eds_or_xdd_file> --outfile <output_filenam> --type <type_selected>
+EDSSharp --infile <eds_or_xdd_file> --outfile <output_filenam> --type <type_selected>
 ```
 Example:
 ```shell
 # Inside the container
-mono ./CANopenEditor-v4/net481/EDSSharp.exe --infile demoDevice.xdd --outfile OD --type CanOpenNodeV4
+EDSSharp --infile demoDevice.xdd --outfile OD --type CanOpenNodeV4
 ```
 
 Exporter types:


### PR DESCRIPTION
- Update Dockerfile syntax
- Update README.md
- Split dockerfile linter
- Split unit-test
- Split docker release process on tag creation
Signed-off-by: Romain PELLETANT <romain.pelletant@guerbet.com>